### PR TITLE
crowdsource updates

### DIFF
--- a/python/crowdsource.py
+++ b/python/crowdsource.py
@@ -118,7 +118,7 @@ def significance_image_lbs(im, model, isig, psf, sz=19):
 
 
 def peakfind(im, model, isig, dq, psf, keepsat=False, threshold=5,
-             blendthreshold=0.3,psfvalsharpcutfac=0.7,psfsharpsat=0.7):
+             blendthreshold=0.3, psfvalsharpcutfac=0.7, psfsharpsat=0.7):
     psfstamp = psf(int(im.shape[0]/2.), int(im.shape[1]/2.), deriv=False,
                    stampsz=59)
     sigim, modelsigim = significance_image(im, model, isig, psfstamp,
@@ -138,7 +138,9 @@ def peakfind(im, model, isig, dq, psf, keepsat=False, threshold=5,
         blendthreshold[nodeblend] = 100
     if dq is not None and numpy.any(dq[x, y] & sharp_maskbit):
         sharp = (dq[x, y] & sharp_maskbit) != 0
-        msharp = ~sharp | psfvalsharpcut(x, y, sigim, isig, psfstamp,psfvalsharpcutfac=psfvalsharpcutfac,psfsharpsat=psfsharpsat)
+        msharp = ~sharp | psfvalsharpcut(
+            x, y, sigim, isig, psfstamp, psfvalsharpcutfac=psfvalsharpcutfac,
+            psfsharpsat=psfsharpsat)
         # keep if not nebulous region or sharp peak.
         m = m & msharp
 
@@ -149,7 +151,8 @@ def peakfind(im, model, isig, dq, psf, keepsat=False, threshold=5,
     return x[m], y[m]
 
 
-def psfvalsharpcut(x, y, sigim, isig, psf, psfvalsharpcutfac=0.7,psfsharpsat=0.7):
+def psfvalsharpcut(x, y, sigim, isig, psf, psfvalsharpcutfac=0.7,
+                   psfsharpsat=0.7):
     xl = numpy.clip(x-1, 0, sigim.shape[0]-1)
     xr = numpy.clip(x+1, 0, sigim.shape[0]-1)
     yl = numpy.clip(y-1, 0, sigim.shape[1]-1)
@@ -241,7 +244,7 @@ def in_padded_region(flatcoord, imshape, pad):
 
 def fit_once(im, x, y, psfs, weight=None,
              psfderiv=False, nskyx=0, nskyy=0,
-             guess=None,bin_weights_on=False):
+             guess=None):
     """Fit fluxes for psfs at x & y in image im.
 
     Args:
@@ -277,10 +280,7 @@ def fit_once(im, x, y, psfs, weight=None,
         weight = numpy.ones_like(im)
     weight = numpy.pad(weight, [pad, pad], constant_values=0.,
                        mode='constant')
-    if bin_weights_on == True:
-        weight = (weight != 0.)
-    else:
-        weight[weight == 0.] = 1.e-20
+    weight[weight == 0.] = 1.e-20
     pix = numpy.arange(stampsz*stampsz, dtype='i4').reshape(stampsz, stampsz)
     # convention: x is the first index, y is the second
     # sorry.
@@ -602,7 +602,7 @@ def get_sizes(x, y, imbs, weight=None, blist=None):
 def fit_im_force(im, x, y, psf, weight=None, dq=None, psfderiv=True,
                  nskyx=0, nskyy=0, refit_psf=False,
                  niter=4, blist=None, derivcentroids=False, refit_sky=True,
-                 startsky=numpy.nan,bin_weights_on=False,msk=None,prb=None):
+                 startsky=numpy.nan, msk=None, prb=None):
     repeat = 3 if psfderiv else 1
     guessflux = None
     msky = 0
@@ -615,13 +615,13 @@ def fit_im_force(im, x, y, psf, weight=None, dq=None, psfderiv=True,
         raise ValueError('derivcentroids only makes sense when psfderiv '
                          'is true')
 
-    for c, s in zip((x, y), im.shape):
-        if numpy.any((c < -0.499) | (c > s-0.501)):
-            c[:] = numpy.clip(c, -0.499, s-0.501)
-            print('Some positions within 0.01 pix of edge of image clipped '
-                  'back to 0.01 pix inside image.')
-
     for titer in range(niter):
+
+        for c, s in zip((x, y), im.shape):
+            if numpy.any((c < -0.499) | (c > s-0.501)):
+                c[:] = numpy.clip(c, -0.499, s-0.501)
+                print('Some positions within 0.01 pix of edge of image '
+                      'clipped back to 0.01 pix inside image.')
         if (refit_sky and
             ((titer > 0) or numpy.any(~numpy.isfinite(startsky)))):
             sky = sky_im(im-model, weight=weight, npix=100)
@@ -641,7 +641,7 @@ def fit_im_force(im, x, y, psf, weight=None, dq=None, psfderiv=True,
         flux, model, msky = fit_once(
                 im-sky, x, y, psfsfull,
                 psfderiv=psfderiv, weight=weight, guess=guess,
-                nskyx=nskyx, nskyy=nskyy, bin_weights_on=bin_weights_on)
+                nskyx=nskyx, nskyy=nskyy)
         import gc
         gc.collect()
         flux = flux[0]
@@ -682,15 +682,15 @@ def fit_im_force(im, x, y, psf, weight=None, dq=None, psfderiv=True,
     stats = compute_stats(x-numpy.round(x), y-numpy.round(y),
                           stamps[0], stamps[2], stamps[3], stamps[1], flux)
     if dq is not None:
-        stats['flags'] = extract_im(xa, ya, dq).astype('i4')
+        stats['flags'] = extract_im(x, y, dq).astype('i4')
     if msk is not None:
-        stats['neb_mask'] = extract_im(xa, ya, msk).astype('i4')
+        stats['neb_mask'] = extract_im(x, y, msk).astype('i4')
     if prb is not None:
-        stats['pN'] = extract_im(xa, ya, prb[:,:,0]).astype('f4')
-        stats['pL'] = extract_im(xa, ya, prb[:,:,1]).astype('f4')
-        stats['pR'] = extract_im(xa, ya, prb[:,:,2]).astype('f4')
-        stats['pE'] = extract_im(xa, ya, prb[:,:,3]).astype('f4')
-    stats['sky'] = extract_im(xa, ya, sky+msky).astype('f4')
+        stats['pN'] = extract_im(x, y, prb[:, :, 0]).astype('f4')
+        stats['pL'] = extract_im(x, y, prb[:, :, 1]).astype('f4')
+        stats['pR'] = extract_im(x, y, prb[:, :, 2]).astype('f4')
+        stats['pE'] = extract_im(x, y, prb[:, :, 3]).astype('f4')
+    stats['sky'] = extract_im(x, y, sky+msky).astype('f4')
 
     stars = OrderedDict([('x', x), ('y', y), ('flux', flux),
                          ('deltx', xcen), ('delty', ycen)] +
@@ -718,23 +718,24 @@ def refit_psf_from_stamps(psf, x, y, xcen, ycen, stamps, name=None, plot=False):
     if hasattr(psf, 'fitfun'):
         psffitfun = psf.fitfun
         npsf = psffitfun(x, y, xcen+xe, ycen+ye, stamps[0],
-                         stamps[1], stamps[2], stamps[3], nkeep=200, name=name, plot=plot)
+                         stamps[1], stamps[2], stamps[3], nkeep=200,
+                         name=name, plot=plot)
         if npsf is not None:
             npsf.fitfun = psffitfun
-        else:
-            shiftx = xcen + xe + x - numpy.round(x)
-            shifty = ycen + ye + y - numpy.round(y)
-            npsf = find_psf(x, shiftx, y, shifty,
-                            stamps[0], stamps[3], stamps[1])
-            # we removed the centroid offset of the model PSFs;
-            # we need to correct the positions to compensate
-        if npsf is not None:
-            xnew = x + xe
-            ynew = y + ye
-            psf = npsf
-        else:
-            xnew = x
-            ynew = y
+    else:
+        shiftx = xcen + xe + x - numpy.round(x)
+        shifty = ycen + ye + y - numpy.round(y)
+        npsf = find_psf(x, shiftx, y, shifty,
+                        stamps[0], stamps[3], stamps[1])
+        # we removed the centroid offset of the model PSFs;
+        # we need to correct the positions to compensate
+    if npsf is not None:
+        xnew = x + xe
+        ynew = y + ye
+        psf = npsf
+    else:
+        xnew = x
+        ynew = y
     return psf, xnew, ynew
 
 
@@ -742,13 +743,9 @@ def fit_im(im, psf, weight=None, dq=None, psfderiv=True,
            nskyx=0, nskyy=0, refit_psf=False,
            verbose=False, miniter=4, maxiter=10, blist=None,
            maxstars=40000, derivcentroids=False,
-           ntilex=1, ntiley=1, fewstars=100, threshold=5, bin_weights_on=False,
-           ccd=None, plot=False, titer_thresh=2, blendthreshu=2, psfvalsharpcutfac=0.7,psfsharpsat=0.7,
-           msk=None,prb=None):
-    if psfvalsharpcutfac != 0.7:
-        print("psfvalsharpcutfac is nonstandard: %.2f" % psfvalsharpcutfac)
-    if psfsharpsat != 0.7:
-        print("psfsharpsat is nonstandard: %.2f" % psfsharpsat)
+           ntilex=1, ntiley=1, fewstars=100, threshold=5,
+           ccd=None, plot=False, titer_thresh=2, blendthreshu=2,
+           psfvalsharpcutfac=0.7, psfsharpsat=0.7, msk=None, prb=None):
     if isinstance(weight, int):
         weight = numpy.ones_like(im)*weight
 
@@ -840,7 +837,7 @@ def fit_im(im, psf, weight=None, dq=None, psfderiv=True,
             tflux, tmodel, tmsky = fit_once(
                 im[sall]-sky[sall], xa[mbda]-bdxaf, ya[mbda]-bdyaf, psfsbda,
                 psfderiv=tpsfderiv, weight=weightbda, guess=guessmbda,
-                nskyx=nskyx, nskyy=nskyy, bin_weights_on=bin_weights_on)
+                nskyx=nskyx, nskyy=nskyy)
             model[spri] = tmodel[sfit]
             msky[spri] = tmsky[sfit]
             ind = numpy.flatnonzero(mbd)
@@ -876,10 +873,10 @@ def fit_im(im, psf, weight=None, dq=None, psfderiv=True,
             if msk is not None:
                 stats['neb_mask'] = extract_im(xa, ya, msk).astype('i4')
             if prb is not None:
-                stats['pN'] = extract_im(xa, ya, prb[:,:,0]).astype('f4')
-                stats['pL'] = extract_im(xa, ya, prb[:,:,1]).astype('f4')
-                stats['pR'] = extract_im(xa, ya, prb[:,:,2]).astype('f4')
-                stats['pE'] = extract_im(xa, ya, prb[:,:,3]).astype('f4')
+                stats['pN'] = extract_im(xa, ya, prb[:, :, 0]).astype('f4')
+                stats['pL'] = extract_im(xa, ya, prb[:, :, 1]).astype('f4')
+                stats['pR'] = extract_im(xa, ya, prb[:, :, 2]).astype('f4')
+                stats['pE'] = extract_im(xa, ya, prb[:, :, 3]).astype('f4')
             stats['sky'] = extract_im(xa, ya, sky+msky).astype('f4')
             break
         guessflux = flux[:len(xa)*repeat:repeat]
@@ -922,9 +919,10 @@ def fit_im(im, psf, weight=None, dq=None, psfderiv=True,
         # which is used for peak finding.  But the faint stars should
         # make little difference?
 
-    ### This is the end of the internal iteration loops
-    ### Prepares found sources for export
-    stars = OrderedDict([('x', xa), ('y', ya), ('flux', flux), ('passno', passno)] +
+    # This is the end of the internal iteration loops
+    # Prepares found sources for export
+    stars = OrderedDict([('x', xa), ('y', ya), ('flux', flux),
+                         ('passno', passno)] +
                         [(f, stats[f]) for f in stats])
     dtypenames = list(stars.keys())
     dtypeformats = [stars[n].dtype for n in dtypenames]
@@ -1152,7 +1150,8 @@ def add_bright_stars(xa, ya, blist, im):
             yout.append(y)
     return (numpy.array(xout, dtype='f4'), numpy.array(yout, dtype='f4'))
 
-## This is almost entirely deprecated for the psf.py module... go look there.
+
+# This is almost entirely deprecated for the psf.py module... go look there.
 def find_psf(xcen, shiftx, ycen, shifty, psfstack, weightstack,
              imstack, stampsz=59, nkeep=100):
     """Find PSF from stamps."""
@@ -1181,10 +1180,6 @@ def find_psf(xcen, shiftx, ycen, shifty, psfstack, weightstack,
         return None
     if numpy.sum(okpsf) > nkeep:
         okpsf = okpsf & (totalflux > -numpy.sort(-totalflux[okpsf])[nkeep-1])
-        #choose_subset = numpy.zeros(okpsf.shape)
-        #choose_subset[okpsf] = numpy.choice(numpy.sum(okpsf), nkeep, replace=Flase)
-        #okpsf = okpsf & choose_subset
-        #print('Too many PSF options %d' % (numpy.sum(okpsf)))
     psfstack = psfstack[okpsf, :, :]
     weightstack = weightstack[okpsf, :, :]
     totalflux = totalflux[okpsf]

--- a/python/crowdsource.py
+++ b/python/crowdsource.py
@@ -704,8 +704,8 @@ def fit_im_force(im, x, y, psf, weight=None, dq=None, psfderiv=True,
     return res
 
 
-
-def refit_psf_from_stamps(psf, x, y, xcen, ycen, stamps, name=None, plot=False):
+def refit_psf_from_stamps(psf, x, y, xcen, ycen, stamps, name=None,
+                          plot=False):
     # how far the centroids of the model PSFs would
     # be from (0, 0) if instantiated there
     # this initial definition includes the known offset (since
@@ -881,8 +881,8 @@ def fit_im(im, psf, weight=None, dq=None, psfderiv=True,
             break
         guessflux = flux[:len(xa)*repeat:repeat]
         if refit_psf and len(xa) > 0:
-            psf, xa, ya = refit_psf_from_stamps(psf, xa, ya, xcen, ycen,
-                                                stamps, name=(titer, ccd), plot=plot)
+            psf, xa, ya = refit_psf_from_stamps(
+                psf, xa, ya, xcen, ycen, stamps, name=(titer, ccd), plot=plot)
         # enforce maximum step
         if derivcentroids:
             maxstep = 1

--- a/python/crowdsource.py
+++ b/python/crowdsource.py
@@ -581,7 +581,7 @@ def get_sizes(x, y, imbs, weight=None, blist=None):
     # but if there are too many of these, don't bother.
     cutoff2 = 20000
     if ((numpy.sum(peakbright > cutoff2) < numpy.sum(peakbright > cutoff)/2)
-        and (numpy.sum(peakbright > cutoff) > 100)):
+        or (numpy.sum(peakbright > cutoff) < 100)):
         sz[peakbright > cutoff2] = 149
     else:
         print('Too many bright sources, using smaller PSF stamp size...')
@@ -602,7 +602,7 @@ def get_sizes(x, y, imbs, weight=None, blist=None):
 def fit_im_force(im, x, y, psf, weight=None, dq=None, psfderiv=True,
                  nskyx=0, nskyy=0, refit_psf=False,
                  niter=4, blist=None, derivcentroids=False, refit_sky=True,
-                 startsky=numpy.nan, msk=None, prb=None):
+                 startsky=numpy.nan):
     repeat = 3 if psfderiv else 1
     guessflux = None
     msky = 0
@@ -683,13 +683,6 @@ def fit_im_force(im, x, y, psf, weight=None, dq=None, psfderiv=True,
                           stamps[0], stamps[2], stamps[3], stamps[1], flux)
     if dq is not None:
         stats['flags'] = extract_im(x, y, dq).astype('i4')
-    if msk is not None:
-        stats['neb_mask'] = extract_im(x, y, msk).astype('i4')
-    if prb is not None:
-        stats['pN'] = extract_im(x, y, prb[:, :, 0]).astype('f4')
-        stats['pL'] = extract_im(x, y, prb[:, :, 1]).astype('f4')
-        stats['pR'] = extract_im(x, y, prb[:, :, 2]).astype('f4')
-        stats['pE'] = extract_im(x, y, prb[:, :, 3]).astype('f4')
     stats['sky'] = extract_im(x, y, sky+msky).astype('f4')
 
     stars = OrderedDict([('x', x), ('y', y), ('flux', flux),
@@ -745,7 +738,7 @@ def fit_im(im, psf, weight=None, dq=None, psfderiv=True,
            maxstars=40000, derivcentroids=False,
            ntilex=1, ntiley=1, fewstars=100, threshold=5,
            ccd=None, plot=False, titer_thresh=2, blendthreshu=2,
-           psfvalsharpcutfac=0.7, psfsharpsat=0.7, msk=None, prb=None):
+           psfvalsharpcutfac=0.7, psfsharpsat=0.7):
     if isinstance(weight, int):
         weight = numpy.ones_like(im)*weight
 
@@ -870,13 +863,6 @@ def fit_im(im, psf, weight=None, dq=None, psfderiv=True,
                                   flux)
             if dq is not None:
                 stats['flags'] = extract_im(xa, ya, dq).astype('i4')
-            if msk is not None:
-                stats['neb_mask'] = extract_im(xa, ya, msk).astype('i4')
-            if prb is not None:
-                stats['pN'] = extract_im(xa, ya, prb[:, :, 0]).astype('f4')
-                stats['pL'] = extract_im(xa, ya, prb[:, :, 1]).astype('f4')
-                stats['pR'] = extract_im(xa, ya, prb[:, :, 2]).astype('f4')
-                stats['pE'] = extract_im(xa, ya, prb[:, :, 3]).astype('f4')
             stats['sky'] = extract_im(xa, ya, sky+msky).astype('f4')
             break
         guessflux = flux[:len(xa)*repeat:repeat]

--- a/python/decam_proc.py
+++ b/python/decam_proc.py
@@ -22,23 +22,26 @@ extrabits = ({'badpix': 2**20,
               'brightstar': 2**23,
               'galaxy': 2**24})
 
-#this is a convenience function for developer access, not used in processing
+
+# this is a convenience function for developer access, not used in processing
 def read(imfn, extname, **kw):
     ivarfn = imfn.replace('_ooi_', '_oow_')
     dqfn = imfn.replace('_ooi_', '_ood_')
     return read_data(imfn, ivarfn, dqfn, extname, **kw)
 
-#wrapper to make file reading easier using the decam pattern
-def decaps_filenames(base,date,filtf,vers):
+
+# wrapper to make file reading easier using the decam pattern
+def decaps_filenames(base, date, filtf, vers):
     imfn = base+date+"_ooi_"+filtf+"_"+vers+".fits.fz"
     ivarfn = base+date+"_oow_"+filtf+"_"+vers+".fits.fz"
     dqfn = base+date+"_ood_"+filtf+"_"+vers+".fits.fz"
     return imfn, ivarfn, dqfn
 
-#actual read function
+
+# actual read function
 def read_data(imfn, ivarfn, dqfn, extname, badpixmask=None,
-              maskdiffuse=True, corrects7=True,wcutoff=0.0,contmask=False,
-              maskgal=False,verbose=False):
+              maskdiffuse=True, corrects7=True, wcutoff=0.0, contmask=False,
+              maskgal=False, verbose=False):
     import warnings
     with warnings.catch_warnings(record=True) as wlist:
         warnings.simplefilter('always')
@@ -68,9 +71,6 @@ def read_data(imfn, ivarfn, dqfn, extname, badpixmask=None,
         # (interpolated, unused, unused)
     imded = 2**imded
     # flag 7 does not seem to indicate problems with the pixels.
-    if wcutoff != 0.0:
-        if verbose:
-            print("weight_cutoff = {}".format(wcutoff))
     mzerowt = (((imded & ~(2**0 | 2**7)) != 0) |
                (imdew < wcutoff) | ~numpy.isfinite(imdew))
     if badpixmask is None:
@@ -92,7 +92,7 @@ def read_data(imfn, ivarfn, dqfn, extname, badpixmask=None,
             if leda is None:
                 leda = galaxy_mask.read_leda_decaps()
                 read_data.leda = leda
-            gmsk = galaxy_mask.galaxy_mask(hdr,leda)
+            gmsk = galaxy_mask.galaxy_mask(hdr, leda)
             if numpy.any(gmsk):
                 imded |= (gmsk * extrabits['galaxy'])
                 imded |= (gmsk * crowdsource.nodeblend_maskbit)
@@ -107,19 +107,20 @@ def read_data(imfn, ivarfn, dqfn, extname, badpixmask=None,
                                  'weights', '27th_try')
             nebmod = nebulosity_mask.load_model(modfn)
             read_data.nebmod = nebmod
-        if contmask == False:
+        if not contmask:
             nebmask = nebulosity_mask.gen_mask(nebmod, imdei) == 0
-        elif contmask == True:
+        else:
             nebprob = nebulosity_mask.gen_prob(nebmod, imdei)
             # hard code decision boundary for now
             alpha = 2.0
             gam = 0.5
             eps = 1e-4
-            decnum = np.zeros((imdei.shape[0],imdei.shape[1]),dtype=numpy.float32)
-            numpy.divide(nebprob[:,:,0] + gam*nebprob[:,:,1],eps + nebprob[:,:,1] + nebprob[:,:,2] + nebprob[:,:,3],out=decnum)
+            decnum = np.zeros((imdei.shape[0], imdei.shape[1]),
+                              dtype=numpy.float32)
+            numpy.divide(nebprob[:, :, 0] + gam*nebprob[:, :, 1],
+                         eps + nebprob[:, :, 1] + nebprob[:, :, 2] +
+                         nebprob[:, :, 3], out=decnum)
             nebmask = (decnum > alpha)
-        else:
-            raise ValueError("Contmask must be bool")
 
         if numpy.any(nebmask):
             imded |= (nebmask * extrabits['diffuse'])
@@ -129,18 +130,20 @@ def read_data(imfn, ivarfn, dqfn, extname, badpixmask=None,
                 print('Masking nebulosity fraction, %5.2f' % (
                     numpy.sum(nebmask)/1./numpy.sum(numpy.isfinite(nebmask))))
     if maskdiffuse:
-        if contmask == True:
+        if contmask:
             return imdei, imdew, imded, nebmask, nebprob
         return imdei, imdew, imded, nebmask, None
     return imdei, imdew, imded, None, None
 
-#main serial processing function for all decam handling
+
+# main serial processing function for all decam handling
 def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
                   outmodel=False, outdirc=None, outdirm=None, verbose=False,
-                  resume=False, bmask_off=False, bmask_deblend=False,
-                  maskgal=False, maskdiffuse=True, contmask=False, nproc=numpy.inf,
+                  resume=False, bmask_deblend=False,
+                  maskgal=False, maskdiffuse=True, contmask=False,
+                  nproc=numpy.inf,
                   extnamelist=None, plot=False, profile=False, miniter=4,
-                  maxiter=10, titer_thresh=2, pixsz=9, wcutoff=0.0, bin_weights_on=False):
+                  maxiter=10, titer_thresh=2, pixsz=9, wcutoff=0.0):
     if profile:
         import cProfile
         import pstats
@@ -149,41 +152,33 @@ def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
         before = hp.heap()
         pr = cProfile.Profile()
         pr.enable()
-    if bin_weights_on == True:
-        if verbose:
-            print("Caution, weights are binarized")
 
-    imfn, ivarfn, dqfn = decaps_filenames(base,date,filtf,vers)
+    imfn, ivarfn, dqfn = decaps_filenames(base, date, filtf, vers)
     with fits.open(imfn) as hdulist:
         extnames = [hdu.name for hdu in hdulist]
     if 'PRIMARY' not in extnames:
         raise ValueError('No PRIMARY header in file')
     prihdr = fits.getheader(imfn, extname='PRIMARY')
-    if not bmask_off:
-        if 'CENTRA' in prihdr:
-            bstarfn = os.path.join(os.environ['DECAM_DIR'], 'data',
-                                   'tyc2brighttrim.fits')
-            brightstars = fits.getdata(bstarfn)
-            from astropy.coordinates.angle_utilities import angular_separation
-            sep = angular_separation(numpy.radians(brightstars['ra']),
-                                     numpy.radians(brightstars['dec']),
-                                     numpy.radians(prihdr['CENTRA']),
-                                     numpy.radians(prihdr['CENTDEC']))
-            sep = numpy.degrees(sep)
-            m = sep < 3
-            brightstars = brightstars[m]
-            dmjd = prihdr['MJD-OBS'] - 51544.5  # J2000 MJD.
-            cosd = numpy.cos(numpy.radians(numpy.clip(brightstars['dec'],
-                                                      -89.9999, 89.9999)))
-            brightstars['ra'] += dmjd*brightstars['pmra']/365.25/cosd/1000/60/60
-            brightstars['dec'] += dmjd*brightstars['pmde']/365.25/1000/60/60
-        else:
-            if verbose:
-                print("WCSCAL Unsucessful, Skipping bright star masking...")
-            brightstars = None
+    if 'CENTRA' in prihdr:
+        bstarfn = os.path.join(os.environ['DECAM_DIR'], 'data',
+                               'tyc2brighttrim.fits')
+        brightstars = fits.getdata(bstarfn)
+        from astropy.coordinates.angle_utilities import angular_separation
+        sep = angular_separation(numpy.radians(brightstars['ra']),
+                                 numpy.radians(brightstars['dec']),
+                                 numpy.radians(prihdr['CENTRA']),
+                                 numpy.radians(prihdr['CENTDEC']))
+        sep = numpy.degrees(sep)
+        m = sep < 3
+        brightstars = brightstars[m]
+        dmjd = prihdr['MJD-OBS'] - 51544.5  # J2000 MJD.
+        cosd = numpy.cos(numpy.radians(numpy.clip(brightstars['dec'],
+                                                  -89.9999, 89.9999)))
+        brightstars['ra'] += dmjd*brightstars['pmra']/365.25/cosd/1000/60/60
+        brightstars['dec'] += dmjd*brightstars['pmde']/365.25/1000/60/60
     else:
         if verbose:
-            print("No bright star masking check was performed!")
+            print("WCSCAL Unsucessful, Skipping bright star masking...")
         brightstars = None
     filt = prihdr['filter']
     # cat filename handling
@@ -232,7 +227,8 @@ def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
     count = 0
     if extnamelist is not None:
         if verbose:
-            s = ("Only running CCD subset: ["+', '.join(['%s']*len(extnamelist))+"]") % tuple(extnamelist)
+            s = ("Only running CCD subset: [" +
+                 ', '.join(['%s']*len(extnamelist))+"]") % tuple(extnamelist)
             print(s)
     # Main CCD for loop
     for name in extnames:
@@ -240,16 +236,18 @@ def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
             continue
         if extnamesdone is not None and name in extnamesdone:
             if verbose:
-                print('Skipping %s, extension %s; already done.' % (imfn, name))
+                print('Skipping %s, extension %s; already done.' %
+                      (imfn, name))
             continue
         if extnamelist is not None and name not in extnamelist:
             continue
         if verbose:
             print('Fitting %s, extension %s.' % (imfn, name))
             sys.stdout.flush()
-        im, wt, dq, msk, prb = read_data(imfn, ivarfn, dqfn, name,
-                               maskdiffuse=maskdiffuse,wcutoff=wcutoff,
-                               contmask=contmask,maskgal=maskgal,verbose=verbose)
+        im, wt, dq, msk, prb = read_data(
+            imfn, ivarfn, dqfn, name, maskdiffuse=maskdiffuse,
+            wcutoff=wcutoff, contmask=contmask, maskgal=maskgal,
+            verbose=verbose)
         hdr = fits.getheader(imfn, extname=name)
         fwhm = hdr.get('FWHM', numpy.median(fwhms))
         if fwhm <= 0.:
@@ -257,7 +255,7 @@ def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
         fwhmmn, fwhmsd = numpy.mean(fwhms), numpy.std(fwhms)
         if fwhmsd > 0.4:
             fwhm = fwhmmn
-        psf = decam_psf(filt[0], fwhm,pixsz=pixsz)
+        psf = decam_psf(filt[0], fwhm, pixsz=pixsz)
         wcs0 = wcs.WCS(hdr)
         if brightstars is not None:
             sep = angular_separation(numpy.radians(brightstars['ra']),
@@ -308,7 +306,7 @@ def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
         decapsid[:] = (prihdr['EXPNUM']*2**32*2**7 +
                        hdr['CCDNUM']*2**32 +
                        numpy.arange(len(cat), dtype='i8'))
-        ### Data Saving
+        # Data Saving
         if verbose:
             print('Writing %s %s, found %d sources.' % (outfn, name, len(cat)))
             sys.stdout.flush()
@@ -326,14 +324,15 @@ def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
         gain = hdr['GAINCRWD']*numpy.ones(len(cat), dtype='f4')
         cat = rec_append_fields(cat, ['ra', 'dec', 'decapsid', 'gain'],
                                 [ra, dec, decapsid, gain])
-        fits.append(outfn, numpy.zeros(0), hdr) # append some header
+        # primary extension includes only header.
+        fits.append(outfn, numpy.zeros(0), hdr)
         hdupsf = fits.BinTableHDU(psf.serialize())
         hdupsf.name = hdr['EXTNAME'][:-4] + '_PSF'
         hducat = fits.BinTableHDU(cat)
         hducat.name = hdr['EXTNAME'][:-4] + '_CAT'
         hdulist = fits.open(outfn, mode='append')
-        hdulist.append(hdupsf) #append the psf field for the ccd
-        hdulist.append(hducat) #append the cat field for the ccd
+        hdulist.append(hdupsf)  # append the psf field for the ccd
+        hdulist.append(hducat)  # append the cat field for the ccd
         hdulist.close(closed=True)
         if outmodel:
             hdr['EXTNAME'] = hdr['EXTNAME'][:-4] + '_MOD'
@@ -395,7 +394,7 @@ def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
 
 def process_image_p(base, date, filtf, vers, outfn=None, overwrite=False,
                   outmodel=False, outdirc=None, outdirm=None, verbose=False,
-                  resume=False, bmask_off=False, bmask_deblend=False,
+                  resume=False, bmask_deblend=False,
                   maskgal=False, maskdiffuse=True, contmask=False, nproc=numpy.inf,
                   extnamelist=None, plot=False, profile=False, miniter=4,
                   maxiter=10,titer_thresh=2,pixsz=9, wcutoff=0.0,bin_weights_on=False,
@@ -672,7 +671,8 @@ def sub_process(args):
         return output
     return output
 
-def decam_psf(filt, fwhm, pixsz = 9, nlinperpar = 3):
+
+def decam_psf(filt, fwhm, pixsz=9):
     if filt not in 'ugrizY':
         tpsf = psfmod.moffat_psf(fwhm, stampsz=511, deriv=False)
         return psfmod.SimplePSF(tpsf)
@@ -694,13 +694,15 @@ def decam_psf(filt, fwhm, pixsz = 9, nlinperpar = 3):
     tpsf = psfmod.stamp2model(numpy.array([tpsf, tpsf, tpsf, tpsf]),
                               normalize=normalizesz)
     pixsz = pixsz
+    nlinperpar = 3
     extraparam = numpy.zeros(
         1, dtype=[('convparam', 'f4', 3*nlinperpar+1),
                   ('resparam', 'f4', (nlinperpar, pixsz, pixsz))])
     extraparam['convparam'][0, 0:4] = [convpsffwhm, 1., 0., 1.]
     extraparam['resparam'][0, :, :, :] = 0.
     tpsf.extraparam = extraparam
-    tpsf.fitfun = partial(psfmod.fit_linear_static_wing, filter=filt, pixsz=pixsz)
+    tpsf.fitfun = partial(psfmod.fit_linear_static_wing, filter=filt,
+                          pixsz=pixsz)
     return tpsf
 
 def correct_sky_offset(im, weight=None):
@@ -728,6 +730,7 @@ def correct_sky_offset(im, weight=None):
     im[:, half:] -= (par[0] + par[1]*xx)
     return im
 
+
 def mask_very_bright_stars(dq, blist):
     dq = dq.copy()
     maskradpermag = 50
@@ -748,12 +751,12 @@ def mask_very_bright_stars(dq, blist):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Fit DECam frame')
 
-    #Required file name information
+    # Required file name information
     parser.add_argument('base', type=str, help='Base names for files')
     parser.add_argument('date', type=str, help='File name date')
     parser.add_argument('filtf', type=str, help='File name filter')
     parser.add_argument('vers', type=str, help='File name version')
-    #Optional file naming directions
+    # Optional file naming directions
     parser.add_argument('--outfn', '-o', type=str,
                         default=None, help='output file name')
     parser.add_argument('--outmodel', '-m', action='store_true',
@@ -763,7 +766,7 @@ if __name__ == "__main__":
                         type=str, default=None)
     parser.add_argument('--outdirm', '-e', help='mod output directory',
                         type=str, default=None)
-    #Run options
+    # Run options
     parser.add_argument('--verbose', '-v', action='store_true',
                         help="prints lots of nice info to cmd line")
     parser.add_argument('--resume', '-r', action='store_true',
@@ -785,7 +788,7 @@ if __name__ == "__main__":
                         default=numpy.inf, help='limit to num ccds run')
     parser.add_argument('--ccdlist', nargs='+', default=None,
                         help='limit run to subset of ccds listed')
-    #Diagnostic options
+    # Diagnostic options
     parser.add_argument('--plot_on', action='store_true',
                         help='save psf diagonsitic plots at each titer')
     parser.add_argument('--profile', '-p', action='store_true',
@@ -798,35 +801,35 @@ if __name__ == "__main__":
                         default=2, help='threshold for deblending increase')
     parser.add_argument('--pixsz', type=int,
                         default=9, help='size of pixelized psf stamp')
-    #Experimental options
+    # Experimental options
     parser.add_argument('--wcutoff', type=float,
                         default=0.0, help='cutoff for inverse variances')
-    parser.add_argument('--bin_weights_on', action='store_true',
-                        help='make WLS depend on binary weights only')
 
     #handle possible ccd level parallelization
     args = parser.parse_args()
     if args.parallel > 1:
-        process_image_p(args.base, args.date, args.filtf, args.vers,
-                      outfn=args.outfn,outmodel=args.outmodel,
-                      outdirc=args.outdirc,outdirm=args.outdirm,
-                      verbose=args.verbose,resume=args.resume,
-                      bmask_off=args.bmask_off,bmask_deblend=args.bmask_deblend,
-                      maskgal=args.maskgal,
-                      maskdiffuse=(not args.no_mask_diffuse),
-                      contmask=args.contmask,num_procs=args.parallel,
-                      nproc=args.ccd_num,extnamelist=args.ccdlist,
-                      plot=args.plot_on,profile=args.profile,
-                      miniter=args.miniter,maxiter=args.maxiter,
-                      titer_thresh=args.titer_thresh,pixsz=args.pixsz,
-                      wcutoff=args.wcutoff,bin_weights_on=args.bin_weights_on
+        process_image_p(
+            args.base, args.date, args.filtf, args.vers,
+            outfn=args.outfn,outmodel=args.outmodel,
+            outdirc=args.outdirc,outdirm=args.outdirm,
+            verbose=args.verbose,resume=args.resume,
+            bmask_deblend=args.bmask_deblend,
+            maskgal=args.maskgal,
+            maskdiffuse=(not args.no_mask_diffuse),
+            contmask=args.contmask,num_procs=args.parallel,
+            nproc=args.ccd_num,extnamelist=args.ccdlist,
+            plot=args.plot_on,profile=args.profile,
+            miniter=args.miniter,maxiter=args.maxiter,
+            titer_thresh=args.titer_thresh,pixsz=args.pixsz,
+            wcutoff=args.wcutoff,
+            bin_weights_on=args.bin_weights_on
         )
     else:
         process_image(args.base, args.date, args.filtf, args.vers,
                       outfn=args.outfn,outmodel=args.outmodel,
                       outdirc=args.outdirc,outdirm=args.outdirm,
                       verbose=args.verbose,resume=args.resume,
-                      bmask_off=args.bmask_off,bmask_deblend=args.bmask_deblend,
+                      bmask_deblend=args.bmask_deblend,
                       maskgal=args.maskgal,
                       maskdiffuse=(not args.no_mask_diffuse),
                       contmask=args.contmask,

--- a/python/decam_proc.py
+++ b/python/decam_proc.py
@@ -11,8 +11,11 @@ from astropy.io import fits
 from astropy import wcs
 from functools import partial
 import crowdsource
-from pqdm.processes import pqdm
-import copy
+from pqdm.threads import pqdm
+# threads rather than processes seems to share memory better so that I don't
+# need to make a function with a million arguments.  This is probably worse
+# from a GIL perspective?  But we really shouldn't be spending much time in
+# pure python routines?
 
 badpixmaskfn = '/n/fink2/www/eschlafly/decam/badpixmasksefs_comp.fits'
 
@@ -136,14 +139,15 @@ def read_data(imfn, ivarfn, dqfn, extname, badpixmask=None,
     return imdei, imdew, imded, None, None
 
 
-# main serial processing function for all decam handling
+# main processing function for all decam handling
 def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
                   outmodel=False, outdirc=None, outdirm=None, verbose=False,
                   resume=False, bmask_deblend=False,
                   maskgal=False, maskdiffuse=True, contmask=False,
                   nproc=numpy.inf,
                   extnamelist=None, plot=False, profile=False, miniter=4,
-                  maxiter=10, titer_thresh=2, pixsz=9, wcutoff=0.0):
+                  maxiter=10, titer_thresh=2, pixsz=9, wcutoff=0.0,
+                  nthreads=1):
     if profile:
         import cProfile
         import pstats
@@ -159,27 +163,28 @@ def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
     if 'PRIMARY' not in extnames:
         raise ValueError('No PRIMARY header in file')
     prihdr = fits.getheader(imfn, extname='PRIMARY')
-    if 'CENTRA' in prihdr:
-        bstarfn = os.path.join(os.environ['DECAM_DIR'], 'data',
-                               'tyc2brighttrim.fits')
-        brightstars = fits.getdata(bstarfn)
-        from astropy.coordinates.angle_utilities import angular_separation
-        sep = angular_separation(numpy.radians(brightstars['ra']),
-                                 numpy.radians(brightstars['dec']),
-                                 numpy.radians(prihdr['CENTRA']),
-                                 numpy.radians(prihdr['CENTDEC']))
-        sep = numpy.degrees(sep)
-        m = sep < 3
-        brightstars = brightstars[m]
-        dmjd = prihdr['MJD-OBS'] - 51544.5  # J2000 MJD.
-        cosd = numpy.cos(numpy.radians(numpy.clip(brightstars['dec'],
-                                                  -89.9999, 89.9999)))
-        brightstars['ra'] += dmjd*brightstars['pmra']/365.25/cosd/1000/60/60
-        brightstars['dec'] += dmjd*brightstars['pmde']/365.25/1000/60/60
-    else:
-        if verbose:
-            print("WCSCAL Unsucessful, Skipping bright star masking...")
-        brightstars = None
+
+    bstarfn = os.path.join(os.environ['DECAM_DIR'], 'data',
+                           'tyc2brighttrim.fits')
+    brightstars = fits.getdata(bstarfn)
+    from astropy.coordinates.angle_utilities import angular_separation
+    from astropy.coordinates import SkyCoord
+    from astropy import units
+    coordcen = SkyCoord(
+        ra=prihdr['RA'], dec=prihdr['DEC'],
+        unit=(units.hourangle, units.deg))
+    sep = angular_separation(numpy.radians(brightstars['ra']),
+                             numpy.radians(brightstars['dec']),
+                             coordcen.ra.to(units.radian).value,
+                             coordcen.dec.to(units.radian).value)
+    sep = numpy.degrees(sep)
+    m = sep < 3
+    brightstars = brightstars[m]
+    dmjd = prihdr['MJD-OBS'] - 51544.5  # J2000 MJD.
+    cosd = numpy.cos(numpy.radians(numpy.clip(brightstars['dec'],
+                                              -89.9999, 89.9999)))
+    brightstars['ra'] += dmjd*brightstars['pmra']/365.25/cosd/1000/60/60
+    brightstars['dec'] += dmjd*brightstars['pmde']/365.25/1000/60/60
     filt = prihdr['filter']
     # cat filename handling
     if outfn is None or len(outfn) == 0:
@@ -230,17 +235,17 @@ def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
             s = ("Only running CCD subset: [" +
                  ', '.join(['%s']*len(extnamelist))+"]") % tuple(extnamelist)
             print(s)
-    # Main CCD for loop
-    for name in extnames:
+
+    def process_one_ccd(name):
         if name == 'PRIMARY':
-            continue
+            return None
         if extnamesdone is not None and name in extnamesdone:
             if verbose:
                 print('Skipping %s, extension %s; already done.' %
                       (imfn, name))
-            continue
+            return None
         if extnamelist is not None and name not in extnamelist:
-            continue
+            return None
         if verbose:
             print('Fitting %s, extension %s.' % (imfn, name))
             sys.stdout.flush()
@@ -258,10 +263,12 @@ def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
         psf = decam_psf(filt[0], fwhm, pixsz=pixsz)
         wcs0 = wcs.WCS(hdr)
         if brightstars is not None:
+            raccdcen, decccdcen = wcs0.all_pix2world(
+                im.shape[1]//2, im.shape[0]//2, 0)
             sep = angular_separation(numpy.radians(brightstars['ra']),
                                      numpy.radians(brightstars['dec']),
-                                     numpy.radians(hdr['CENRA1']),
-                                     numpy.radians(hdr['CENDEC1']))
+                                     numpy.radians(raccdcen),
+                                     numpy.radians(decccdcen))
             sep = numpy.degrees(sep)
             m = sep < 0.2
             # CCD is 4094 pix wide => everything is at most 0.15 deg
@@ -287,14 +294,11 @@ def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
             blist = None
 
         # the actual fit (which has a nested iterative fit)
-        res = crowdsource.fit_im(im, psf, ntilex=4, ntiley=2,
-                                 weight=wt, dq=dq,
-                                 psfderiv=True, refit_psf=True,
-                                 verbose=verbose, blist=blist,
-                                 maxstars=320000,bin_weights_on=bin_weights_on,
-                                 ccd=name, plot=plot, miniter=miniter, maxiter=maxiter,
-                                 titer_thresh=titer_thresh,msk=msk,prb=prb)
-
+        res = crowdsource.fit_im(
+            im, psf, ntilex=4, ntiley=2, weight=wt, dq=dq, psfderiv=True,
+            refit_psf=True, verbose=verbose, blist=blist, maxstars=320000,
+            ccd=name, plot=plot, miniter=miniter, maxiter=maxiter,
+            titer_thresh=titer_thresh, msk=msk, prb=prb)
         cat, modelim, skyim, psf = res
         if len(cat) > 0:
             ra, dec = wcs0.all_pix2world(cat['y'], cat['x'], 0.)
@@ -306,10 +310,6 @@ def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
         decapsid[:] = (prihdr['EXPNUM']*2**32*2**7 +
                        hdr['CCDNUM']*2**32 +
                        numpy.arange(len(cat), dtype='i8'))
-        # Data Saving
-        if verbose:
-            print('Writing %s %s, found %d sources.' % (outfn, name, len(cat)))
-            sys.stdout.flush()
         hdr['EXTNAME'] = hdr['EXTNAME']+'_HDR'
         if numpy.any(wt > 0):
             hdr['GAINCRWD'] = numpy.nanmedian((im*wt**2.)[wt > 0])
@@ -324,6 +324,22 @@ def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
         gain = hdr['GAINCRWD']*numpy.ones(len(cat), dtype='f4')
         cat = rec_append_fields(cat, ['ra', 'dec', 'decapsid', 'gain'],
                                 [ra, dec, decapsid, gain])
+        return cat, modelim, skyim, psf, hdr, msk
+
+    # Main CCD for loop
+    if nthreads > 1:
+        iterator = pqdm(extnames, process_one_ccd, n_jobs=nthreads)
+    else:
+        iterator = (process_one_ccd(x) for x in extnames)
+
+    for res in iterator:
+        if res is None:  # no need to process this extension.
+            continue
+        cat, modelim, skyim, psf, hdr, msk = res
+        # Data Saving
+        if verbose:
+            print('Writing %s %s, found %d sources.' % (outfn, name, len(cat)))
+            sys.stdout.flush()
         # primary extension includes only header.
         fits.append(outfn, numpy.zeros(0), hdr)
         hdupsf = fits.BinTableHDU(psf.serialize())
@@ -348,39 +364,40 @@ def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
             modhdulist.append(fits.CompImageHDU(skyim, hdr, **compkw))
             if msk is not None:
                 hdr['EXTNAME'] = hdr['EXTNAME'][:-4] + '_MSK'
-                modhdulist.append(fits.CompImageHDU(msk.astype('i4'), hdr, **compkw))
-            if contmask == True:
-                ## here we grossly reuse the arrays previously allocated
-                ## in order to save memory and allocation times
-                dq.fill(-1)
-                im.fill(0)
-                scale=8
-                from ternary.helpers import simplex_iterator
-                d = []
-                dkey = []
-                for (i,j,k) in simplex_iterator(scale):
-                    d.append([i/scale,j/scale,k/scale])
-                    dkey.append((i,j))
-                darr = np.array(d)
+                modhdulist.append(fits.CompImageHDU(msk.astype('i4'), hdr,
+                                                    **compkw))
+            # if contmask == True:
+            #     ## here we grossly reuse the arrays previously allocated
+            #     ## in order to save memory and allocation times
+            #     dq.fill(-1)
+            #     im.fill(0)
+            #     scale=8
+            #     from ternary.helpers import simplex_iterator
+            #     d = []
+            #     dkey = []
+            #     for (i,j,k) in simplex_iterator(scale):
+            #         d.append([i/scale,j/scale,k/scale])
+            #         dkey.append((i,j))
+            #     darr = np.array(d)
 
-                prb[:,:,2] += prb[:,:,3]
-                prb[:,:,3] = 3
+            #     prb[:,:,2] += prb[:,:,3]
+            #     prb[:,:,3] = 3
 
-                for i in range(len(d)):
-                    np.sum((prb[:,:,0:3]-darr[np.newaxis,np.newaxis,i,:])**2,axis=2,out=im)
-                    np.less(im,prb[:,:,3],out=msk)
-                    prb[:,:,3][msk] = im[msk]
-                    np.copyto(dq,i,where=msk)
+            #     for i in range(len(d)):
+            #         np.sum((prb[:,:,0:3]-darr[np.newaxis,np.newaxis,i,:])**2,axis=2,out=im)
+            #         np.less(im,prb[:,:,3],out=msk)
+            #         prb[:,:,3][msk] = im[msk]
+            #         np.copyto(dq,i,where=msk)
 
-                cnts = np.zeros(len(d))
-                for i in range(len(d)):
-                    cnts[i] = np.sum(np.equal(dq,i))
-                cnts *= len(d)/(prb.shape[0]*prb.shape[1])
-                extname = hdr['EXTNAME'][:-4] + '_NLRE'
-                c1 = fits.Column(name='NLRE_keys0', array=np.array(dkey)[:,0], format='I')
-                c2 = fits.Column(name='NLRE_keys1', array=np.array(dkey)[:,1], format='I')
-                c3 = fits.Column(name='NLRE_vals', array=cnts, format='E')
-                modhdulist.append(fits.BinTableHDU.from_columns([c1, c2, c3],name=extname))
+            #     cnts = np.zeros(len(d))
+            #     for i in range(len(d)):
+            #         cnts[i] = np.sum(np.equal(dq,i))
+            #     cnts *= len(d)/(prb.shape[0]*prb.shape[1])
+            #     extname = hdr['EXTNAME'][:-4] + '_NLRE'
+            #     c1 = fits.Column(name='NLRE_keys0', array=np.array(dkey)[:,0], format='I')
+            #     c2 = fits.Column(name='NLRE_keys1', array=np.array(dkey)[:,1], format='I')
+            #     c3 = fits.Column(name='NLRE_vals', array=cnts, format='E')
+            #     modhdulist.append(fits.BinTableHDU.from_columns([c1, c2, c3],name=extname))
             modhdulist.close(closed=True)
         count += 1
         if count >= nproc:
@@ -391,285 +408,6 @@ def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
         after = hp.heap()
         leftover = after - before
         print(leftover)
-
-def process_image_p(base, date, filtf, vers, outfn=None, overwrite=False,
-                  outmodel=False, outdirc=None, outdirm=None, verbose=False,
-                  resume=False, bmask_deblend=False,
-                  maskgal=False, maskdiffuse=True, contmask=False, nproc=numpy.inf,
-                  extnamelist=None, plot=False, profile=False, miniter=4,
-                  maxiter=10,titer_thresh=2,pixsz=9, wcutoff=0.0,bin_weights_on=False,
-                  num_procs=1):
-
-    if profile:
-        import cProfile
-        import pstats
-        from guppy import hpy
-        hp = hpy()
-        before = hp.heap()
-        pr = cProfile.Profile()
-        pr.enable()
-    if bin_weights_on == True:
-        if verbose:
-            print("Caution, weights are binarized")
-
-    imfn, ivarfn, dqfn = decaps_filenames(base,date,filtf,vers)
-    with fits.open(imfn) as hdulist:
-        extnames = [hdu.name for hdu in hdulist]
-    if 'PRIMARY' not in extnames:
-        raise ValueError('No PRIMARY header in file')
-    prihdr = fits.getheader(imfn, extname='PRIMARY')
-    if not bmask_off:
-        if 'CENTRA' in prihdr:
-            bstarfn = os.path.join(os.environ['DECAM_DIR'], 'data',
-                                   'tyc2brighttrim.fits')
-            brightstars = fits.getdata(bstarfn)
-            from astropy.coordinates.angle_utilities import angular_separation
-            sep = angular_separation(numpy.radians(brightstars['ra']),
-                                     numpy.radians(brightstars['dec']),
-                                     numpy.radians(prihdr['CENTRA']),
-                                     numpy.radians(prihdr['CENTDEC']))
-            sep = numpy.degrees(sep)
-            m = sep < 3
-            brightstars = brightstars[m]
-            dmjd = prihdr['MJD-OBS'] - 51544.5  # J2000 MJD.
-            cosd = numpy.cos(numpy.radians(numpy.clip(brightstars['dec'],
-                                                      -89.9999, 89.9999)))
-            brightstars['ra'] += dmjd*brightstars['pmra']/365.25/cosd/1000/60/60
-            brightstars['dec'] += dmjd*brightstars['pmde']/365.25/1000/60/60
-        else:
-            if verbose:
-                print("WCSCAL Unsucessful, Skipping bright star masking...")
-            brightstars = None
-    else:
-        if verbose:
-            print("No bright star masking check was performed!")
-        brightstars = None
-    filt = prihdr['filter']
-    # cat filename handling
-    if outfn is None or len(outfn) == 0:
-        outfn = os.path.splitext(os.path.basename(imfn))[0]
-        if outfn[-5:] == '.fits':
-            outfn = outfn[:-5]
-        outfn = outfn + '.cat.fits'
-    if outdirc is not None:
-        outfn = os.path.join(outdirc, outfn)
-    if not resume or not os.path.exists(outfn):
-        fits.writeto(outfn, None, prihdr, overwrite=overwrite)
-        extnamesdone = None
-    else:
-        hdulist = fits.open(outfn)
-        extnamesdone = []
-        for hdu in hdulist:
-            if hdu.name == 'PRIMARY':
-                continue
-            ext, exttype = hdu.name.split('_')
-            if exttype != 'CAT':
-                continue
-            extnamesdone.append(ext)
-        hdulist.close()
-    # model filename handling
-    if outmodel:
-        outmodelfn = os.path.splitext(os.path.basename(imfn))[0]
-        if outmodelfn[-5:] == '.fits':
-            outmodelfn = outmodelfn[:-5]
-        outmodelfn = outmodelfn + '.mod.fits'
-        if outdirm is not None:
-            outmodelfn = os.path.join(outdirm, outmodelfn)
-        if (not resume or not os.path.exists(outmodelfn)):
-            fits.writeto(outmodelfn, None, prihdr, overwrite=overwrite)
-    # fwhm scrape all the ccds
-    fwhms = []
-    for name in extnames:
-        if name == 'PRIMARY':
-            continue
-        hdr = fits.getheader(imfn, extname=name)
-        if 'FWHM' in hdr:
-            fwhms.append(hdr['FWHM'])
-    fwhms = numpy.array(fwhms)
-    fwhms = fwhms[fwhms > 0]
-
-    newexts = numpy.setdiff1d(extnames,['PRIMARY'])
-    if extnamesdone != None:
-        newexts = numpy.setdiff1d(newexts,extnamesdone)
-    if extnamelist != None:
-        newexts = numpy.intersect1d(newexts,extnamelist)
-
-    if nproc != numpy.inf:
-        max_nproc = numpy.min([nproc, len(newexts)])
-        nargs = [(n, outfn, imfn, ivarfn, dqfn, outmodel, outmodelfn, maskdiffuse, wcutoff, fwhms, bin_weights_on, verbose, filt, brightstars,bmask_deblend, prihdr, plot, miniter, maxiter,titer_thresh,pixsz,maskgal,contmask) for n in newexts[0:max_nproc]]
-    else:
-        nargs = [(n, outfn, imfn, ivarfn, dqfn, outmodel, outmodelfn, maskdiffuse, wcutoff, fwhms, bin_weights_on, verbose, filt, brightstars,bmask_deblend, prihdr, plot, miniter, maxiter,titer_thresh,pixsz,maskgal,contmask) for n in newexts]
-
-    result = pqdm(nargs, sub_process, n_jobs=num_procs)
-
-    for s in result:
-        hdr = fits.Header.fromstring(s[0])
-        fits.append(outfn, numpy.zeros(0), hdr) # append some header
-
-        hdupsf = fits.BinTableHDU(s[1])
-        hdupsf.name = hdr['EXTNAME'][:-4] + '_PSF'
-
-        hducat = fits.BinTableHDU(s[2])
-        hducat.name = hdr['EXTNAME'][:-4] + '_CAT'
-
-        hdulist = fits.open(outfn, mode='append')
-        hdulist.append(hdupsf) #append the psf field for the ccd
-        hdulist.append(hducat) #append the cat field for the ccd
-        hdulist.close(closed=True)
-
-        if outmodel:
-            hdr['EXTNAME'] = hdr['EXTNAME'][:-4] + '_MOD'
-            compkw = {'compression_type': 'GZIP_1',
-                      'quantize_method': 1, 'quantize_level': -4,
-                      'tile_size': s[3].shape}
-            model = fits.CompImageHDU(s[3], hdr, **compkw)
-            hdr['EXTNAME'] = hdr['EXTNAME'][:-4] + '_SKY'
-            sky = fits.CompImageHDU(s[4], hdr, **compkw)
-
-            modhdulist = fits.open(outmodelfn, mode='append')
-            modhdulist.append(model)
-            modhdulist.append(sky)
-            if s[5] is not None:
-                hdr['EXTNAME'] = hdr['EXTNAME'][:-4] + '_MSK'
-                msk=fits.CompImageHDU(s[5].astype('i4'), hdr, **compkw)
-                modhdulist.append(msk)
-            if contmask == True:
-                extname = hdr['EXTNAME'][:-4] + '_NLRE'
-                c1 = fits.Column(name='NLRE_keys0', array=np.array(s[6])[:,0], format='I')
-                c2 = fits.Column(name='NLRE_keys1', array=np.array(s[6])[:,1], format='I')
-                c3 = fits.Column(name='NLRE_vals', array=s[7], format='E')
-                modhdulist.append(fits.BinTableHDU.from_columns([c1, c2, c3],name=extname))
-            modhdulist.close(closed=True)
-
-    if profile:
-        pr.disable()
-        pstats.Stats(pr).sort_stats('cumulative').print_stats(60)
-        after = hp.heap()
-        leftover = after - before
-        print(leftover)
-
-def sub_process(args):
-    name, outfn, imfn, ivarfn, dqfn, outmodel, outmodelfn, maskdiffuse, wcutoff, fwhms, bin_weights_on, verbose, filt, brightstars, bmask_deblend,prihdr, plot, miniter, maxiter,titer_thresh,pixsz,maskgal,contmask = args
-    if verbose:
-        print('Fitting %s, extension %s.' % (imfn, name))
-        sys.stdout.flush()
-    im, wt, dq, msk, prb = read_data(imfn, ivarfn, dqfn, name,
-                           maskdiffuse=maskdiffuse,wcutoff=wcutoff,
-                           contmask=contmask,maskgal=maskgal,verbose=verbose)
-    hdr = fits.getheader(imfn, extname=name)
-    fwhm = hdr.get('FWHM', numpy.median(fwhms))
-    if fwhm <= 0.:
-        fwhm = 4.
-    fwhmmn, fwhmsd = numpy.mean(fwhms), numpy.std(fwhms)
-    if fwhmsd > 0.4:
-        fwhm = fwhmmn
-    psf = decam_psf(filt[0], fwhm, pixsz)
-    wcs0 = wcs.WCS(hdr)
-    from astropy.coordinates.angle_utilities import angular_separation
-    if brightstars is not None:
-        sep = angular_separation(numpy.radians(brightstars['ra']),
-                                 numpy.radians(brightstars['dec']),
-                                 numpy.radians(hdr['CENRA1']),
-                                 numpy.radians(hdr['CENDEC1']))
-        sep = numpy.degrees(sep)
-        m = sep < 0.2
-        # CCD is 4094 pix wide => everything is at most 0.15 deg
-        # from center
-        if numpy.any(m):
-            yb, xb = wcs0.all_world2pix(brightstars['ra'][m],
-                                        brightstars['dec'][m], 0)
-            vmag = brightstars['vtmag'][m]
-            # WCS module and I order x and y differently...
-            m = ((xb > 0) & (xb < im.shape[0]) &
-                 (yb > 0) & (yb < im.shape[1]))
-            if numpy.any(m):
-                xb, yb = xb[m], yb[m]
-                vmag = vmag[m]
-                blist = [xb, yb, vmag]
-                if not bmask_deblend:
-                    dq = mask_very_bright_stars(dq, blist)
-            else:
-                blist = None
-        else:
-            blist = None
-    else:
-        blist = None
-
-    # the actual fit (which has a nested iterative fit)
-    res = crowdsource.fit_im(im, psf, ntilex=4, ntiley=2,
-                             weight=wt, dq=dq,
-                             psfderiv=True, refit_psf=True,
-                             verbose=verbose, blist=blist,
-                             maxstars=320000,bin_weights_on=bin_weights_on,
-                             ccd=name, plot=plot, miniter=miniter, maxiter=maxiter,
-                             titer_thresh=titer_thresh,msk=msk,prb=prb)
-
-    cat, modelim, skyim, psf = res
-    if len(cat) > 0:
-        ra, dec = wcs0.all_pix2world(cat['y'], cat['x'], 0.)
-    else:
-        ra = numpy.zeros(0, dtype='f8')
-        dec = numpy.zeros(0, dtype='f8')
-    from numpy.lib.recfunctions import rec_append_fields
-    decapsid = numpy.zeros(len(cat), dtype='i8')
-    decapsid[:] = (prihdr['EXPNUM']*2**32*2**7 +
-                   hdr['CCDNUM']*2**32 +
-                   numpy.arange(len(cat), dtype='i8'))
-    if verbose:
-        print('Writing %s %s, found %d sources.' % (outfn, name, len(cat)))
-        sys.stdout.flush()
-    hdr['EXTNAME'] = hdr['EXTNAME']+'_HDR'
-    if numpy.any(wt > 0):
-        hdr['GAINCRWD'] = numpy.nanmedian((im*wt**2.)[wt > 0])
-        hdr['SKYCRWD'] = numpy.nanmedian(skyim[wt > 0])
-    else:
-        hdr['GAINCRWD'] = 4
-        hdr['SKYCRWD'] = 0
-    if len(cat) > 0:
-        hdr['FWHMCRWD'] = numpy.nanmedian(cat['fwhm'])
-    else:
-        hdr['FWHMCRWD'] = 0.0
-    gain = hdr['GAINCRWD']*numpy.ones(len(cat), dtype='f4')
-    cat = rec_append_fields(cat, ['ra', 'dec', 'decapsid', 'gain'],
-                            [ra, dec, decapsid, gain])
-    if contmask == True:
-        ## here we grossly reuse the arrays previously allocated
-        ## in order to save memory and allocation times
-        dq.fill(-1)
-        im.fill(0)
-        scale=8
-        from ternary.helpers import simplex_iterator
-        d = []
-        dkey = []
-        for (i,j,k) in simplex_iterator(scale):
-            d.append([i/scale,j/scale,k/scale])
-            dkey.append((i,j))
-        darr = np.array(d)
-
-        prb[:,:,2] += prb[:,:,3]
-        prb[:,:,3] = 3
-
-        for i in range(len(d)):
-            np.sum((prb[:,:,0:3]-darr[np.newaxis,np.newaxis,i,:])**2,axis=2,out=im)
-            np.less(im,prb[:,:,3],out=msk)
-            prb[:,:,3][msk] = im[msk]
-            np.copyto(dq,i,where=msk)
-
-        cnts = np.zeros(len(d))
-        for i in range(len(d)):
-            cnts[i] = np.sum(np.equal(dq,i))
-        cnts *= len(d)/(prb.shape[0]*prb.shape[1])
-
-    output = [hdr.tostring(), psf.serialize(), cat]
-    if outmodel:
-        output.append(modelim)
-        output.append(skyim)
-        output.append(msk)
-        if contmask:
-            output.append(dkey)
-            output.append(cnts)
-        return output
-    return output
 
 
 def decam_psf(filt, fwhm, pixsz=9):
@@ -704,6 +442,7 @@ def decam_psf(filt, fwhm, pixsz=9):
     tpsf.fitfun = partial(psfmod.fit_linear_static_wing, filter=filt,
                           pixsz=pixsz)
     return tpsf
+
 
 def correct_sky_offset(im, weight=None):
     xx = numpy.arange(im.shape[0], dtype='f4')
@@ -748,6 +487,7 @@ def mask_very_bright_stars(dq, blist):
                              crowdsource.sharp_maskbit)
     return dq
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Fit DECam frame')
 
@@ -760,7 +500,7 @@ if __name__ == "__main__":
     parser.add_argument('--outfn', '-o', type=str,
                         default=None, help='output file name')
     parser.add_argument('--outmodel', '-m', action='store_true',
-                        default=False, help='output model file')
+                        default=False, help='output model file?')
 
     parser.add_argument('--outdirc', '-d', help='cat output directory',
                         type=str, default=None)
@@ -771,8 +511,6 @@ if __name__ == "__main__":
                         help="prints lots of nice info to cmd line")
     parser.add_argument('--resume', '-r', action='store_true',
                         help='resume if file already exists')
-    parser.add_argument('--bmask_off', '-b', action='store_true',
-                        help='turn bright star masking off')
     parser.add_argument('--bmask_deblend', '-q', action='store_true',
                         help='turn deblending around bright stars back on')
     parser.add_argument('--maskgal', '-g', action='store_true',
@@ -782,15 +520,15 @@ if __name__ == "__main__":
     parser.add_argument('--contmask', '-c', action='store_true',
                         help='use continuous nebulosity masking model')
     # Fast short run options
-    parser.add_argument('--parallel', type=int,
-                        default=1, help='num of parallel processors')
-    parser.add_argument('--ccd_num', type=int,
-                        default=numpy.inf, help='limit to num ccds run')
+    parser.add_argument('--nthreads', type=int,
+                        default=1, help='num of parallel threads')
+    parser.add_argument('--nccds', type=int,
+                        default=numpy.inf, help='run only first nccds ccds')
     parser.add_argument('--ccdlist', nargs='+', default=None,
                         help='limit run to subset of ccds listed')
     # Diagnostic options
     parser.add_argument('--plot_on', action='store_true',
-                        help='save psf diagonsitic plots at each titer')
+                        help='plot psf diagonsitic plots at each titer')
     parser.add_argument('--profile', '-p', action='store_true',
                         help='print profiling statistics')
     parser.add_argument('--miniter', type=int,
@@ -805,37 +543,18 @@ if __name__ == "__main__":
     parser.add_argument('--wcutoff', type=float,
                         default=0.0, help='cutoff for inverse variances')
 
-    #handle possible ccd level parallelization
     args = parser.parse_args()
-    if args.parallel > 1:
-        process_image_p(
-            args.base, args.date, args.filtf, args.vers,
-            outfn=args.outfn,outmodel=args.outmodel,
-            outdirc=args.outdirc,outdirm=args.outdirm,
-            verbose=args.verbose,resume=args.resume,
-            bmask_deblend=args.bmask_deblend,
-            maskgal=args.maskgal,
-            maskdiffuse=(not args.no_mask_diffuse),
-            contmask=args.contmask,num_procs=args.parallel,
-            nproc=args.ccd_num,extnamelist=args.ccdlist,
-            plot=args.plot_on,profile=args.profile,
-            miniter=args.miniter,maxiter=args.maxiter,
-            titer_thresh=args.titer_thresh,pixsz=args.pixsz,
-            wcutoff=args.wcutoff,
-            bin_weights_on=args.bin_weights_on
-        )
-    else:
-        process_image(args.base, args.date, args.filtf, args.vers,
-                      outfn=args.outfn,outmodel=args.outmodel,
-                      outdirc=args.outdirc,outdirm=args.outdirm,
-                      verbose=args.verbose,resume=args.resume,
-                      bmask_deblend=args.bmask_deblend,
-                      maskgal=args.maskgal,
-                      maskdiffuse=(not args.no_mask_diffuse),
-                      contmask=args.contmask,
-                      nproc=args.ccd_num,extnamelist=args.ccdlist,
-                      plot=args.plot_on,profile=args.profile,
-                      miniter=args.miniter,maxiter=args.maxiter,
-                      titer_thresh=args.titer_thresh,pixsz=args.pixsz,
-                      wcutoff=args.wcutoff,bin_weights_on=args.bin_weights_on
-        )
+    process_image(args.base, args.date, args.filtf, args.vers,
+                  outfn=args.outfn, outmodel=args.outmodel,
+                  outdirc=args.outdirc, outdirm=args.outdirm,
+                  verbose=args.verbose, resume=args.resume,
+                  bmask_deblend=args.bmask_deblend,
+                  maskgal=args.maskgal,
+                  maskdiffuse=(not args.no_mask_diffuse),
+                  contmask=args.contmask,
+                  nproc=args.nccds, extnamelist=args.ccdlist,
+                  plot=args.plot_on, profile=args.profile,
+                  miniter=args.miniter, maxiter=args.maxiter,
+                  titer_thresh=args.titer_thresh, pixsz=args.pixsz,
+                  wcutoff=args.wcutoff,
+                  nthreads=args.nthreads)

--- a/python/decam_proc.py
+++ b/python/decam_proc.py
@@ -310,10 +310,10 @@ def process_image(base, date, filtf, vers, outfn=None, overwrite=False,
             hdr['FWHMCRWD'] = 0.0
         gain = hdr['GAINCRWD']*numpy.ones(len(cat), dtype='f4')
         if prb is not None:
-            for i in range(prb.shape[1]):
+            for i in range(prb.shape[2]):
                 prnebdat = [
-                    crowdsource.extract_im(cat['x'], cat['y'], prb[:, i])
-                    for i in range(prb.shape[1])]
+                    crowdsource.extract_im(cat['x'], cat['y'], prb[:, :, i])
+                    for i in range(prb.shape[2])]
                 prnebnames = ['pN', 'pR', 'pL', 'pE']
             else:
                 prnebdat = []

--- a/python/nebulosity_mask.py
+++ b/python/nebulosity_mask.py
@@ -14,6 +14,7 @@ import resource
 # quiet all of the annoying tensorflow compile model warnings
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 
+
 def equalize_histogram(img, n_bins=256, asinh_stretch=False):
     # from http://www.janeriksolem.net/2009/06/histogram-equalization-with-python-and.html
 
@@ -32,6 +33,7 @@ def equalize_histogram(img, n_bins=256, asinh_stretch=False):
     img_equalized = np.interp(img.flatten(), bins[:-1], cdf)
 
     return img_equalized.reshape(img.shape), cdf
+
 
 def equalize_histogram_wise(img, n_bins=256, asinh_stretch=False):
     # tweaked version for WISE
@@ -54,6 +56,7 @@ def equalize_histogram_wise(img, n_bins=256, asinh_stretch=False):
 
     return img_equalized.reshape(img.shape), cdf
 
+
 def load_model(fname_base):
     with open(fname_base + '.json', 'r') as f:
         model_json = f.read()
@@ -63,16 +66,18 @@ def load_model(fname_base):
 
     return model
 
+
 def subimages(img, shape, shiftx=0, shifty=0):
     j = np.arange(shiftx, img.shape[0]+shape[0]-1+shiftx, shape[0], dtype=int)
     k = np.arange(shifty, img.shape[1]+shape[1]-1+shifty, shape[1], dtype=int)
 
-    jm = j[j<=img.shape[0]]
-    km = k[k<=img.shape[1]]
+    jm = j[j <= img.shape[0]]
+    km = k[k <= img.shape[1]]
 
     for j0, j1 in zip(jm[:-1], jm[1:]):
         for k0, k1 in zip(km[:-1], km[1:]):
             yield j0, k0, img[j0:j1, k0:k1]
+
 
 def gen_mask(model, img):
     img = np.pad(img, 1, mode='constant', constant_values=np.median(img))
@@ -90,39 +95,48 @@ def gen_mask(model, img):
 
     return mask[1:-1, 1:-1]
 
+
 def gen_prob(model, img):
     img = np.pad(img, 1, mode='constant', constant_values=np.median(img))
     _, h, w, _ = model.layers[0].input_shape
 
-    mask = np.zeros((img.shape[0]-2,img.shape[1]-2,4),dtype=numpy.float32)
-    mask_cnt = np.zeros((img.shape[0]-2,img.shape[1]-2,4),dtype=numpy.float32)
+    mask = np.zeros((img.shape[0]-2, img.shape[1]-2, 4),
+                    dtype=numpy.float32)
+    mask_cnt = np.zeros((img.shape[0]-2, img.shape[1]-2, 4),
+                        dtype=numpy.float32)
 
-    #print ('Memory %s (KB)' % resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    # print ('Memory %s (KB)' % resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
 
     eps = 1e-4
-    for shx in [0,128,256,384]:
-        for shy in [0,128,256,384]:
-            for j0, k0, subimg in subimages(img, (h, w),shiftx=shx,shifty=shy):
-                subimg, _ = equalize_histogram(subimg.astype('f8'),
-                                               asinh_stretch=True, n_bins=3000)
+    for shx in [0, 128, 256, 384]:
+        for shy in [0, 128, 256, 384]:
+            for j0, k0, subimg in subimages(img, (h, w), shiftx=shx,
+                                            shifty=shy):
+                subimg, _ = equalize_histogram(
+                    subimg.astype('f8'), asinao_stretch=True, n_bins=3000)
                 subimg /= 255.
                 subimg.shape = (1, subimg.shape[0], subimg.shape[1], 1)
                 pred = model.predict(subimg, batch_size=1)[0]
 
-                x0,x1=np.clip([j0-1,j0+h-1],0,img.shape[0]-1)
-                y0,y1=np.clip([k0-1,k0+w-1],0,img.shape[1]-1)
+                x0, x1 = np.clip([j0-1, j0+h-1], 0, img.shape[0]-1)
+                y0, y1 = np.clip([k0-1, k0+w-1], 0, img.shape[1]-1)
 
-                mask[x0:x1, y0:y1,0] += pred[0]*(pred[0]+eps)
-                mask[x0:x1, y0:y1,1] += pred[1]*(pred[0]+eps)
-                mask[x0:x1, y0:y1,2] += pred[2]*(pred[0]+eps)
-                mask[x0:x1, y0:y1,3] += pred[3]*(pred[0]+eps)
+                mask[x0:x1, y0:y1, 0] += pred[0]*(pred[0]+eps)
+                mask[x0:x1, y0:y1, 1] += pred[1]*(pred[0]+eps)
+                mask[x0:x1, y0:y1, 2] += pred[2]*(pred[0]+eps)
+                mask[x0:x1, y0:y1, 3] += pred[3]*(pred[0]+eps)
                 mask_cnt[x0:x1, y0:y1] += (pred[0]+eps)
-    np.divide(mask,mask_cnt, out=mask)
-    filters.gaussian(mask[:,:,0], sigma=(128),truncate=1,multichannel=False,output=mask[:,:,0])
-    filters.gaussian(mask[:,:,1], sigma=(128),truncate=1,multichannel=False,output=mask[:,:,1])
-    filters.gaussian(mask[:,:,2], sigma=(128),truncate=1,multichannel=False,output=mask[:,:,2])
-    filters.gaussian(mask[:,:,3], sigma=(128),truncate=1,multichannel=False,output=mask[:,:,3])
+    np.divide(mask, mask_cnt, out=mask)
+    filters.gaussian(mask[:, :, 0], sigma=(128), truncate=1,
+                     multichannel=False, output=mask[:, :, 0])
+    filters.gaussian(mask[:, :, 1], sigma=(128), truncate=1,
+                     multichannel=False, output=mask[:, :, 1])
+    filters.gaussian(mask[:, :, 2], sigma=(128), truncate=1,
+                     multichannel=False, output=mask[:, :, 2])
+    filters.gaussian(mask[:, :, 3], sigma=(128), truncate=1,
+                     multichannel=False, output=mask[:, :, 3])
     return mask
+
 
 def gen_mask_wise(model, img):
     _, h, w, _ = model.layers[0].input_shape
@@ -138,11 +152,10 @@ def gen_mask_wise(model, img):
         # light, normal, nebulosity
         predcondense = np.argmax(pred*[1., 1., 0.5])
         mask[j0:j0+h, k0:k0+w] = predcondense
-        # if predcondense == 2:
-        #     print(pred)
 
     mask[mask == 0] = 1  # nebulosity_light -> normal
     return mask
+
 
 def test_plots(model, imfns, extname='N26'):
     from matplotlib import pyplot as p
@@ -164,6 +177,7 @@ def test_plots(model, imfns, extname='N26'):
             p.draw()
             p.savefig(os.path.basename(timfn)+'.mask.png')
 
+
 def main():
     from PIL import Image
 
@@ -177,6 +191,7 @@ def main():
     mask.save('toy_data/test_image_mask.png')
 
     return 0
+
 
 if __name__ == '__main__':
     main()

--- a/python/psf.py
+++ b/python/psf.py
@@ -621,7 +621,8 @@ def select_stamps(psfstack, imstack, weightstack, shiftx, shifty):
     return okpsf
 
 
-def shift_and_normalize_stamps(psfstack, modstack, weightstack, shiftx, shifty):
+def shift_and_normalize_stamps(psfstack, modstack, weightstack,
+                               shiftx, shifty):
     xr = numpy.round(shiftx)
     yr = numpy.round(shifty)
     psfstack = psfstack.copy()
@@ -666,12 +667,8 @@ def extract_params_moffat(param, order):
              param[nperpar*2:nperpar*3])]
 
 
-def plot_psf_fits(stamp, x, y, model, isig, name=None):
+def plot_psf_fits(stamp, x, y, model, isig, name=None, save=False):
     from matplotlib import pyplot as p
-    import matplotlib
-    matplotlib.use('Agg')
-    p.style.use('dark_background')
-    import colorcet
 
     datim = numpy.zeros((stamp.shape[1]*10, stamp.shape[1]*10), dtype='f4')
     modim = numpy.zeros((stamp.shape[1]*10, stamp.shape[1]*10), dtype='f4')
@@ -690,19 +687,21 @@ def plot_psf_fits(stamp, x, y, model, isig, name=None):
             modim0 = model[ind, :, :]
             datim[i*sz:(i+1)*sz, j*sz:(j+1)*sz] = datim0-medmodel
             modim[i*sz:(i+1)*sz, j*sz:(j+1)*sz] = modim0-medmodel
-    p.figure(figsize=(24,8), dpi=150)
-    p.subplot(1,3,1)
-    p.imshow(datim, aspect='equal', vmin=-0.005, vmax=0.005, cmap='cet_bkr')
+    p.figure(figsize=(24, 8), dpi=150)
+    p.subplot(1, 3, 1)
+    p.imshow(datim, aspect='equal', vmin=-0.005, vmax=0.005, cmap='binary')
     p.title('Stamps')
-    p.subplot(1,3,2)
-    p.imshow(modim, aspect='equal', vmin=-0.005, vmax=0.005, cmap='cet_bkr')
+    p.subplot(1, 3, 2)
+    p.imshow(modim, aspect='equal', vmin=-0.005, vmax=0.005, cmap='binary')
     p.title('Model')
-    p.subplot(1,3,3)
-    p.imshow(datim-modim, aspect='equal', vmin=-0.001, vmax=0.001, cmap='cet_bkr')
+    p.subplot(1, 3, 3)
+    p.imshow(datim-modim, aspect='equal', vmin=-0.001, vmax=0.001,
+             cmap='binary')
     p.title('Residuals')
-    p.savefig('psf_'+name[1]+'_'+str(name[0])+'.png', dpi=150, bbox_inches='tight', pad_inches=0.1)
+    if save:
+        p.savefig('psf_'+name[1]+'_'+str(name[0])+'.png', dpi=150,
+                  bbox_inches='tight', pad_inches=0.1)
 
-    #numpy.savez('psf_loc',x=x,y=y)
 
 def plot_psf_fits_brightness(stamp, x, y, model, isig):
     from matplotlib import pyplot as p
@@ -998,7 +997,7 @@ def stamp2model(corn, normalize=-1):
 
 def fit_linear_static_wing(x, y, xcen, ycen, stamp, imstamp, modstamp,
                            isig, pixsz=9, nkeep=200, plot=False,
-                           filter='g', name=None, nlinperpar = 3):
+                           filter='g', name=None):
     # clean and shift the PSFs first.
     shiftx = xcen + x - numpy.round(x)
     shifty = ycen + y - numpy.round(y)
@@ -1090,6 +1089,7 @@ def fit_linear_static_wing(x, y, xcen, ycen, stamp, imstamp, modstamp,
     cornresid = modresid.render_model(xx, yy, deriv=False,
                                       stampsz=outstampsz)
     modtotal = stamp2model(cornwing+cornresid, normalize=normalizesz)
+    nlinperpar = 3
     extraparam = numpy.zeros(
         1, dtype=[('convparam', 'f4', 4*nlinperpar+1),
                   ('resparam', 'f4', (nlinperpar, pixsz, pixsz))])

--- a/python/psf.py
+++ b/python/psf.py
@@ -1132,7 +1132,7 @@ def linear_static_wing_from_record(record, filter='g'):
 
 def wise_psf_fit(x, y, xcen, ycen, stamp, imstamp, modstamp,
                  isig, pixsz=9, nkeep=200, plot=False,
-                 psfstamp=None, grid=False):
+                 psfstamp=None, grid=False, name=None):
     if psfstamp is None:
         raise ValueError('psfstamp must be set')
     # clean and shift the PSFs first.

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,7 +6,6 @@ guppy3
 keras
 matplotlib
 numpy
-pqdm
 scipy
 scikit-image
 python-ternary

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,14 +2,12 @@
 ####### requirements.txt #######
 #
 astropy
-colorcet
 guppy3
 keras
 matplotlib
 numpy
 pqdm
 scipy
-pydl
 scikit-image
 python-ternary
 tensorflow >= 2


### PR DESCRIPTION
Here's a first attempt to get in some of the changes I think we want before merging back to master.  I've not done a good job of checking that this doesn't have any regressions, unfortunately; partially I want to push something back on you so you see what I'm thinking before we diverge too much.  I think we could go ahead and merge with changes like these, plus fixing up the contmask writing that I broke.  I might also argue for retiring the old-style decam_proc nebulosity masking, though I understand if you want to keep it for the moment for testing.  But eventually I want to declare your improvements a replacement and jettison the old version.  Let me know if this looks sane to you.

* I harmonized the style with my usual linter in the main modules I wrote; sorry for the noise that makes.
* I got rid of some verbosity.
* I tried to give the parallel and serial code paths more overlap.  In the way I wrote this, I saved having to write a function with a million arguments by using thread-based rather than process-based parallelism.  I think that will be okay since most time should be in C where I don't think the GIL is being held, but I may misunderstand.  If you find that the thread-based parallelism isn't doing the right thing, it would be simple to replace the ThreadPoolExecutor with a ProcessPoolExecutor after adding a million arguments to process_one_ccd and promoting it to a stand-alone function.
* I pushed the nebulosity stats for each source back out of crowdsource into decam_proc.  The rationale is that I don't necessarily want crowdsource knowing any details of the nebulosity modeling, just that it needs to treat certain regions with nodeblend and sharp mask bits specially.
* I've currently disabled functionality outputting the contmasks for each CCD because I didn't really understand it.  Could we just output an 8x8 subsampled image or something?  That would be really small relative to everything else and still very much oversample the real image?  I'd like to get rid of the ternary dependency and have that be an external analysis tool or something.  I see the text that this is to save memory / allocation times, but it seems to me that as soon as you pull out every 8x8th pixel things must be tiny and fast relative to everything else.
* Got rid of some dependencies that I thought could be easily replaced with existing dependencies.
* Version of continuous nebulosity masking for WISE.
* I broke another feature where you automatically saved PSF plots to disk.  That looked reasonable, but if you want this, let's find an implementation that doesn't break using the plots interactively.  i.e., the call to use the backend probably needs to go in decam_proc:__main__, and maybe --plot needs to take more possible values to distinguish between saving plots vs. just making them.
* I got rid of the bin_weights_on feature.  I think I'd advocate that if we want to use this, the ivars should get modified before being sent to crowdsource to be 0/1 or 0/median or something.  That would automatically get the other uncertainties computed correctly given the changed weights.
* The random image I was running on at NERSC didn't have all of the astrometry related keywords this code had expected, even though WCSCAL was successful.  I made the code depend on different keywords that should be more robust.
